### PR TITLE
Fix single space output in text

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -121,7 +121,7 @@ const revHorseMap = (multiSymbol) => {
 
 export const horseToAscii = (sentence) => {
     if (sentence && sentence.length) {
-        return sentence.split('  ')
+        return sentence.trim().split('  ')
             .map(w => w.split(' ').map(revHorseMap).join(''))
             .join(' ');
     } else {


### PR DESCRIPTION
Hey there!
I added a trim to the input string before the splits as fix to #18.
As you mentioned, the space turns into `''` which doesn't match with any case in the switch, returning the default `?`.